### PR TITLE
Add `child_spec/1` function to `TelemetryMetricsPrometheus.Core`

### DIFF
--- a/lib/core/registry.ex
+++ b/lib/core/registry.ex
@@ -17,6 +17,11 @@ defmodule TelemetryMetricsPrometheus.Core.Registry do
   # name - https://prometheus.io/docs/instrumenting/writing_exporters/#naming
 
   def start_link(opts) do
+    case Keyword.get(opts, :metrics) do
+      nil -> raise "no :metrics key defined in options"
+      _ -> :ok
+    end
+
     GenServer.start_link(__MODULE__, opts, name: opts[:name])
   end
 

--- a/test/registry_test.exs
+++ b/test/registry_test.exs
@@ -15,7 +15,7 @@ defmodule TelemetryMetricsPrometheus.Core.RegistryTest do
       Metrics.summary("http.request.duration")
     ]
 
-    opts = [name: :test]
+    opts = [name: :test, metrics: []]
 
     %{definitions: definitions, opts: opts}
   end
@@ -35,6 +35,10 @@ defmodule TelemetryMetricsPrometheus.Core.RegistryTest do
     end)
 
     cleanup()
+  end
+
+  test "errors if metrics aren't set" do
+    assert {:error, _} = start_supervised({Registry, [name: :test]})
   end
 
   test "returns an error for duplicate events", %{definitions: definitions, opts: opts} do


### PR DESCRIPTION
The `TelemetryMetricsPrometheus.Core` module has a `child_spec/1` function and a
`start_link/1` function. These functions start the registry, or add a
registry to the calling supervisor.

These functions can be used to add `TelemetryMetricsPrometheus.Core` to the
supervision tree of the calling application. The `init/2` function has been
deprecated.

The functions for registering metrics and monitoring the table have been moved
into the registry, however their functionality remains the same.

The metrics can be passed in as an option, this reflects how the
`Telemetry.Metrics.ConsoleReporter` module works.